### PR TITLE
Chore: Rename compute shader for mosaic effect

### DIFF
--- a/scripts/@Stylize_K_template.anm2
+++ b/scripts/@Stylize_K_template.anm2
@@ -33,7 +33,7 @@ obj.pixelshader("saturate", "object", "object", {
 --track1:Y Blocks,1,16384,32,1
 --check0:Sharp Colors,0
 --value@_0:PI,{}
---[[computeshader@mosaic_map:
+--[[computeshader@mosaic_ave:
 ${SHADER_MOSAIC_AVE}
 ]]
 --[[pixelshader@mosaic_draw:
@@ -76,7 +76,7 @@ if (sharp_col) then
 else
     local n = 256
     obj.setoption("drawtarget", "tempbuffer", bx, by)
-    obj.computeshader("mosaic_map", "tempbuffer", "object", {
+    obj.computeshader("mosaic_ave", "tempbuffer", "object", {
         bx, by,
         w, h,
         n,

--- a/shaders/mosaic_ave.hlsl
+++ b/shaders/mosaic_ave.hlsl
@@ -17,7 +17,7 @@ groupshared float4 col_buf[64];
 groupshared uint cnt_buf[64];
 
 [numthreads(8, 8, 1)]
-void mosaic_map(CS_INPUT input) {
+void mosaic_ave(CS_INPUT input) {
     for (uint i = input.gid.x; i < uint(total_blocks); i += uint(total_groups)) {
         uint map_w = uint(blocks.x);
         uint2 block_idx = uint2(i % map_w, i / map_w);


### PR DESCRIPTION
This PR renames the compute shader used in the mosaic effect to improve clarity.